### PR TITLE
Fixes bug when user tries to sign up with an existing email address

### DIFF
--- a/backend/src/users/api.py
+++ b/backend/src/users/api.py
@@ -32,7 +32,7 @@ def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     user = services.get_user_by_email(session=session, email=user_in.email)
     if user:
         raise HTTPException(
-            status_code=400,
+            status_code=409,
             detail="The user with this email already exists in the system",
         )
     user_create = UserCreate.model_validate(user_in)

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -107,6 +107,7 @@
       "invalidCredentials": "Invalid credentials",
       "invalidName": "Invalid name",
       "invalidEmail": "Invalid email address",
+      "emailAlreadyInUse": "Email is already in use",
       "loginFailed": "Login failed",
       "passwordConfirmationIsRequired": "Password confirmation is required",
       "passwordsDoNotMatch": "The passwords do not match",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -105,6 +105,7 @@
       "invalidCredentials": "Credenciales inválidas",
       "invalidName": "Nombre inválido",
       "invalidEmail": "Dirección de correo electrónico inválida",
+      "emailAlreadyInUse": "Esa dirección de correo electrónico ya existe",
       "loginFailed": "Error al iniciar sesión",
       "passwordConfirmationIsRequired": "Confirmación de contraseña es requerida",
       "passwordsDoNotMatch": "Las contraseñas no coinciden",

--- a/frontend/public/locales/nl/translation.json
+++ b/frontend/public/locales/nl/translation.json
@@ -105,6 +105,7 @@
       "invalidCredentials": "Ongeldige inloggegevens",
       "invalidName": "Ongeldige naam",
       "invalidEmail": "Ongeldig e-mailadres",
+      "emailAlreadyInUse": "Dat e-mailadres bestaat al",
       "loginFailed": "Inloggen mislukt",
       "passwordConfirmationIsRequired": "Bevestiging van wachtwoord is vereist",
       "passwordsDoNotMatch": "De wachtwoorden komen niet overeen",

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -52,12 +52,18 @@ const useAuth = () => {
           : 'body' in err && typeof err.body === 'object' && err.body
             ? String(err.body.detail) || t('general.errors.somethingWentWrong')
             : t('general.errors.somethingWentWrong')
-
       toaster.create({
         title: t('general.errors.errorCreatingAccount'),
         description: errDetail,
         type: 'error',
       })
+      if (err.status === 409) {       
+        setError(
+          t('general.errors.emailAlreadyInUse') || t('general.errors.somethingWentWrong')
+        )
+      } else {
+        setError(t('general.errors.somethingWentWrong'))
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['users'] })

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -57,12 +57,12 @@ const useAuth = () => {
         description: errDetail,
         type: 'error',
       })
-      if (err.status === 409) {       
+      if (err.status === 409) {
         setError(
           t('general.errors.emailAlreadyInUse') || t('general.errors.somethingWentWrong')
         )
       } else {
-        setError(t('general.errors.somethingWentWrong'))
+        setError(errDetail)
       }
     },
     onSettled: () => {

--- a/frontend/src/routes/_publicLayout/signup.tsx
+++ b/frontend/src/routes/_publicLayout/signup.tsx
@@ -25,7 +25,7 @@ interface UserRegisterForm extends UserRegister {
 
 function SignUp() {
   const { t } = useTranslation()
-  const { signUpMutation } = useAuth()
+  const { signUpMutation, error, resetError } = useAuth()
   const {
     register,
     handleSubmit,
@@ -42,8 +42,16 @@ function SignUp() {
     },
   })
 
-  const onSubmit: SubmitHandler<UserRegisterForm> = (data) => {
-    signUpMutation.mutate(data)
+  const onSubmit: SubmitHandler<UserRegisterForm> = async (data) => {
+    if (isSubmitting) return
+
+    resetError()
+
+    try {
+      await signUpMutation.mutateAsync(data)
+    } catch {
+      // error is handled by useAuth hook
+    }
   }
 
   return (
@@ -89,6 +97,11 @@ function SignUp() {
               {errors.email && (
                 <Text color="red.500" fontSize="sm">
                   {errors.email.message}
+                </Text>
+              )}
+              {error && (
+                <Text color="red.500" fontSize="sm">
+                  {error}
                 </Text>
               )}
             </Field.Root>

--- a/frontend/src/routes/_publicLayout/signup.tsx
+++ b/frontend/src/routes/_publicLayout/signup.tsx
@@ -42,16 +42,10 @@ function SignUp() {
     },
   })
 
-  const onSubmit: SubmitHandler<UserRegisterForm> = async (data) => {
+  const onSubmit: SubmitHandler<UserRegisterForm> = (data) => {
     if (isSubmitting) return
-
     resetError()
-
-    try {
-      await signUpMutation.mutateAsync(data)
-    } catch {
-      // error is handled by useAuth hook
-    }
+    signUpMutation.mutate(data)
   }
 
   return (


### PR DESCRIPTION
This PR handles issue #8 

### Changes made:

- Changes the backend HTTP Error code from 400 to 409 for a more specific error case.
- Adds a placeholder in the signup component for errors similar to the login component.
- Displays the specific error message when an email already exists.
- Updates translation for all three languages.