### PR TITLE
fix: include-src-client-in-biome

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -4,7 +4,7 @@
     "enabled": true
   },
   "files": {
-    "ignore": ["node_modules", "src/routeTree.gen.ts", "src/components/ui", "src/client/*"]
+    "ignore": ["node_modules", "src/routeTree.gen.ts", "src/components/ui"]
   },
   "linter": {
     "enabled": true,
@@ -25,7 +25,7 @@
     "indentStyle": "space",
     "indentWidth": 2,
     "lineWidth": 100,
-    "ignore": ["src/components/ui", "src/assets/*", "src/client/*"]
+    "ignore": ["src/components/ui", "src/assets/*"]
   },
   "javascript": {
     "formatter": {


### PR DESCRIPTION
Fix Biome formatting for generated client code
- Updated biome.json so that files generated by the generate_client script in src/client/* are now formatted and have imports organized by Biome.
- Linting remains disabled for generated code to avoid unnecessary errors.